### PR TITLE
Fix nSequence value in createrawtransaction

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -373,6 +373,11 @@ Value createrawtransaction(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
         CTxIn in(COutPoint(txid, nOutput));
+
+        const Value& sequence = find_value(o, "sequence");
+        if (sequence.type() == int_type)
+            in.nSequence = sequence.get_int();
+
         rawTx.vin.push_back(in);
     }
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -327,7 +327,8 @@ Value createrawtransaction(const Array& params, bool fHelp)
             "     [\n"
             "       {\n"
             "         \"txid\":\"id\",  (string, required) The transaction id\n"
-            "         \"vout\":n        (numeric, required) The output number\n"
+            "         \"vout\":n,       (numeric, required) The output number\n"
+            "         \"sequence\":n    (numeric, optional) The sequence number\n"
             "       }\n"
             "       ,...\n"
             "     ]\n"
@@ -375,8 +376,12 @@ Value createrawtransaction(const Array& params, bool fHelp)
         CTxIn in(COutPoint(txid, nOutput));
 
         const Value& sequence = find_value(o, "sequence");
-        if (sequence.type() == int_type)
-            in.nSequence = sequence.get_int();
+        if (sequence.type() == int_type) {
+            int nSequence = sequence.get_int();
+            if (nSequence < 0)
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, sequence must be positive");
+            in.nSequence = nSequence;
+        }
 
         rawTx.vin.push_back(in);
     }


### PR DESCRIPTION
The documentation for `createrawtransaction` states that we can include an optional sequence value for transaction inputs. Currently the wallet ignores this value and always sets it as the 32-bit unsigned maximum value.

This pull request makes the wallet use the submitted sequence value. If the sequence value is not included then the functionality is the same as before. I have tested both.

I'm working on a project where I need to send TX with custom sequence values and this makes my life slightly easier :)