### PR TITLE
Reintroduce testnet

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -27,6 +27,11 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return false;
     }
+    // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+    if (!SelectParamsFromCommandLine()) {
+        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+        return false;
+    }
 
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("--help"))
     {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -54,6 +54,11 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;
         }
+        // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+        if (!SelectParamsFromCommandLine()) {
+            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+            return false;
+        }
 
         if (mapArgs.count("-?") || mapArgs.count("--help"))
         {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -32,6 +32,8 @@ class CChainParams
 public:
     enum Network {
         MAIN,
+        TESTNET,
+        REGTEST,
 
         MAX_NETWORK_TYPES
     };
@@ -83,8 +85,16 @@ const CChainParams &Params();
 //Sets the params returned by Params() to those for the given network.
 void SelectParams(CChainParams::Network network);
 
-//Looks for outdated nets and then calls SelectParams as appropriate.
+//Looks for -regtest or -testnet and then calls SelectParams as appropriate.
 bool SelectParamsFromCommandLine();
 
+inline bool TestNet() {
+    // Note: it's deliberate that this returns "false" for regression test mode.
+    return Params().NetworkID() == CChainParams::TESTNET;
+}
+
+inline bool RegTest() {
+    return Params().NetworkID() == CChainParams::REGTEST;
+}
 
 #endif

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -56,8 +56,35 @@ namespace Checkpoints
         500.0         // * estimated number of transactions per day after checkpoint
     };
 
+    static MapCheckpoints mapCheckpointsTestnet =
+        boost::assign::map_list_of
+        ( 0, uint256("0x2a8e100939494904af825b488596ddd536b3a96226ad02e0f7ab7ae472b27a8e"))
+        ;
+    static const CCheckpointData dataTestnet = {
+        &mapCheckpointsTestnet,
+        1428109151,
+        1,
+        1
+    };
+
+    static MapCheckpoints mapCheckpointsRegtest =
+        boost::assign::map_list_of
+        ( 0, uint256("0x2a8e100939494904af825b488596ddd536b3a96226ad02e0f7ab7ae472b27a8e"))
+        ;
+    static const CCheckpointData dataRegtest = {
+        &mapCheckpointsRegtest,
+        1428109151,
+        1,
+        1
+    };
+
     const CCheckpointData &Checkpoints() {
-        return data;
+        if (Params().NetworkID() == CChainParams::TESTNET)
+            return dataTestnet;
+        else if (Params().NetworkID() == CChainParams::MAIN)
+            return data;
+        else
+            return dataRegtest;
     }
 
     bool CheckBlock(int nHeight, const uint256& hash)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -233,7 +233,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -maxreceivebuffer=<n>  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 5000)") + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
     strUsage += "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (IPv4 or IPv6)") + "\n";
-    strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 11337)") + "\n";
+    strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 11337 or testnet: 14321)") + "\n";
     strUsage += "  -proxy=<ip:port>       " + _("Connect through SOCKS proxy") + "\n";
     strUsage += "  -seednode=<ip>         " + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n";
     strUsage += "  -socks=<n>             " + _("Select SOCKS version for -proxy (4 or 5, default: 5)") + "\n";
@@ -297,8 +297,12 @@ std::string HelpMessage(HelpMessageMode hmm)
         strUsage += "  -printblocktree        " + _("Print block tree on startup (default: 0)") + "\n";
         strUsage += "  -printpriority         " + _("Log transaction priority and fee per kB when mining blocks (default: 0)") + "\n";
         strUsage += "  -privdb                " + _("Sets the DB_PRIVATE flag in the wallet db environment (default: 1)") + "\n";
+        strUsage += "  -regtest               " + _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + "\n";
+        strUsage += "                         " + _("This is intended for regression testing tools and app development.") + "\n";
+        strUsage += "                         " + _("In this mode -genproclimit controls how many blocks are generated immediately.") + "\n";
     }
     strUsage += "  -shrinkdebugfile       " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n";
+    strUsage += "  -testnet               " + _("Use the test network") + "\n";
 
     strUsage += "\n" + _("Block creation options:") + "\n";
     strUsage += "  -blockminsize=<n>      " + _("Set minimum block size in bytes (default: 0)") + "\n";
@@ -310,7 +314,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
     strUsage += "  -rpcuser=<user>        " + _("Username for JSON-RPC connections") + "\n";
     strUsage += "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n";
-    strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 9332)") + "\n";
+    strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 9332 or testnet: 18332)") + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified IP address") + "\n";
     strUsage += "  -rpcthreads=<n>        " + _("Set the number of threads to service RPC calls (default: 4)") + "\n";
 
@@ -538,7 +542,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         InitWarning(_("Warning: Deprecated argument -debugnet ignored, use -debug=net"));
 
     fBenchmark = GetBoolArg("-benchmark", false);
-    mempool.setSanityCheck(GetBoolArg("-checkmempool", false));
+    mempool.setSanityCheck(GetBoolArg("-checkmempool", RegTest()));
     Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
@@ -847,6 +851,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 }
 
                 // If the loaded chain has a wrong genesis, bail out immediately
+                // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && chainActive.Genesis() == NULL)
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
                 

--- a/src/main.h
+++ b/src/main.h
@@ -832,7 +832,11 @@ public:
 
     int GetAlgoWorkFactor() const
     {
-        if (nHeight < nRichForkHeight)
+        if (!TestNet() && (nHeight < nRichForkHeight))
+        {
+            return 1;
+        }
+        if (TestNet() && (nHeight < 100))
         {
             return 1;
         }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -178,9 +178,9 @@ public:
     /// Create options model
     void createOptionsModel();
     /// Create main window
-    void createWindow();
+    void createWindow(bool isaTestNet);
     /// Create splash screen
-    void createSplashScreen();
+    void createSplashScreen(bool isaTestNet);
 
     /// Request core initialization
     void requestInitialize();
@@ -317,18 +317,18 @@ void BitcoinApplication::createOptionsModel()
     optionsModel = new OptionsModel();
 }
 
-void BitcoinApplication::createWindow()
+void BitcoinApplication::createWindow(bool isaTestNet)
 {
-    window = new BitcoinGUI(0);
+    window = new BitcoinGUI(isaTestNet, 0);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
     pollShutdownTimer->start(200);
 }
 
-void BitcoinApplication::createSplashScreen()
+void BitcoinApplication::createSplashScreen(bool isaTestNet)
 {
-    SplashScreen *splash = new SplashScreen(QPixmap(), 0);
+    SplashScreen *splash = new SplashScreen(QPixmap(), 0, isaTestNet);
     splash->setAttribute(Qt::WA_DeleteOnClose);
     splash->show();
     connect(this, SIGNAL(splashFinished(QWidget*)), splash, SLOT(slotFinish(QWidget*)));
@@ -535,12 +535,22 @@ int main(int argc, char *argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
+    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    if (!SelectParamsFromCommandLine()) {
+        QMessageBox::critical(0, QObject::tr("Auroracoin"), QObject::tr("Error: Invalid combination of -regtest and -testnet."));
+        return 1;
+    }
 #ifdef ENABLE_WALLET
     // Parse URIs on command line -- this can affect Params()
     if (!PaymentServer::ipcParseCommandLine(argc, argv))
         exit(0);
 #endif
-    QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
+    bool isaTestNet = Params().NetworkID() != CChainParams::MAIN;
+    // Allow for separate UI settings for testnets
+    if (isaTestNet)
+        QApplication::setApplicationName(QAPP_APP_NAME_TESTNET);
+    else
+        QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
     // Re-initialize translations after changing application name (language in network-specific settings can be different)
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
 
@@ -580,11 +590,11 @@ int main(int argc, char *argv[])
     uiInterface.InitMessage.connect(InitMessage);
 
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min", false))
-        app.createSplashScreen();
+        app.createSplashScreen(isaTestNet);
 
     try
     {
-        app.createWindow();
+        app.createWindow(isaTestNet);
         app.requestInitialize();
 #if defined(Q_OS_WIN) && QT_VERSION >= 0x050000
         WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("Smileycoin Core didn't yet exit safely..."), (HWND)app.getMainWinId());

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -58,7 +58,7 @@
 
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";
 
-BitcoinGUI::BitcoinGUI(QWidget *parent) :
+BitcoinGUI::BitcoinGUI(bool fIsTestnet, QWidget *parent) :
     QMainWindow(parent),
     clientModel(0),
     walletFrame(0),
@@ -116,12 +116,25 @@ BitcoinGUI::BitcoinGUI(QWidget *parent) :
         windowTitle += tr("Node");
     }
 
+    if (!fIsTestnet)
+    {
 #ifndef Q_OS_MAC
         QApplication::setWindowIcon(QIcon(":icons/bitcoin"));
         setWindowIcon(QIcon(":icons/bitcoin"));
 #else
         MacDockIconHandler::instance()->setIcon(QIcon(":icons/bitcoin"));
 #endif
+    }
+    else
+    {
+        windowTitle += " " + tr("[testnet]");
+#ifndef Q_OS_MAC
+        QApplication::setWindowIcon(QIcon(":icons/bitcoin_testnet"));
+        setWindowIcon(QIcon(":icons/bitcoin_testnet"));
+#else
+        MacDockIconHandler::instance()->setIcon(QIcon(":icons/bitcoin_testnet"));
+#endif
+    }
     setWindowTitle(windowTitle);
 
 #if defined(Q_OS_MAC) && QT_VERSION < 0x050000
@@ -151,7 +164,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent) :
 
     // Create actions for the toolbar, menu bar and tray/dock icon
     // Needs walletFrame to be initialized
-    createActions();
+    createActions(fIsTestnet);
 
     // Create application menu bar
     createMenuBar();
@@ -160,7 +173,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent) :
     createToolBars();
 
     // Create system tray icon and notification
-    createTrayIcon();
+    createTrayIcon(fIsTestnet);
 
     // Create status bar
     statusBar();
@@ -234,7 +247,7 @@ BitcoinGUI::~BitcoinGUI()
 #endif
 }
 
-void BitcoinGUI::createActions()
+void BitcoinGUI::createActions(bool fIsTestnet)
 {
     QActionGroup *tabGroup = new QActionGroup(this);
 
@@ -292,8 +305,11 @@ void BitcoinGUI::createActions()
     quitAction->setStatusTip(tr("Quit application"));
     quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
     quitAction->setMenuRole(QAction::QuitRole);
-    aboutAction = new QAction(QIcon(":/icons/bitcoin"), tr("&About Smileycoin Core"), this);
-    aboutAction->setStatusTip(tr("Show information about Smileycoin"));
+    if (!fIsTestnet)
+        aboutAction = new QAction(QIcon(":/icons/bitcoin"), tr("&About Smileycoin Core"), this);
+    else
+        aboutAction = new QAction(QIcon(":/icons/bitcoin_testnet"), tr("&About Smileycoin Core"), this);
+    aboutAction->setStatusTip(tr("Show information about Smileyoin"));
     aboutAction->setMenuRole(QAction::AboutRole);
 #if QT_VERSION < 0x050000
     aboutQtAction = new QAction(QIcon(":/trolltech/qmessagebox/images/qtlogo-64.png"), tr("About &Qt"), this);
@@ -305,7 +321,10 @@ void BitcoinGUI::createActions()
     optionsAction = new QAction(QIcon(":/icons/options"), tr("&Options..."), this);
     optionsAction->setStatusTip(tr("Modify configuration options for Smileycoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
-    toggleHideAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Show / Hide"), this);
+    if (!fIsTestnet)
+        toggleHideAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Show / Hide"), this);
+    else
+        toggleHideAction = new QAction(QIcon(":/icons/bitcoin_testnet"), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
@@ -495,13 +514,21 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     openAction->setEnabled(enabled);
 }
 
-void BitcoinGUI::createTrayIcon()
+void BitcoinGUI::createTrayIcon(bool fIsTestnet)
 {
 #ifndef Q_OS_MAC
     trayIcon = new QSystemTrayIcon(this);
 
-    trayIcon->setToolTip(tr("Smileycoin client"));
-    trayIcon->setIcon(QIcon(":/icons/toolbar"));
+    if (!fIsTestnet)
+    {
+        trayIcon->setToolTip(tr("Smileycoin client"));
+        trayIcon->setIcon(QIcon(":/icons/toolbar"));
+    }
+    else
+    {
+        trayIcon->setToolTip(tr("Smileycoin client") + " " + tr("[testnet]"));
+        trayIcon->setIcon(QIcon(":/icons/toolbar_testnet"));
+    }
 
     trayIcon->show();
 #endif

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -39,7 +39,7 @@ class BitcoinGUI : public QMainWindow
 public:
     static const QString DEFAULT_WALLET;
 
-    explicit BitcoinGUI(QWidget *parent = 0);
+    explicit BitcoinGUI(bool fIsTestnet = false, QWidget *parent = 0);
     ~BitcoinGUI();
 
     /** Set the client model.
@@ -107,13 +107,13 @@ private:
     int spinnerFrame;
 
     /** Create the main UI actions. */
-    void createActions();
+    void createActions(bool fIsTestnet);
     /** Create the menu bar and sub-menus. */
     void createMenuBar();
     /** Create the toolbars */
     void createToolBars();
     /** Create system tray icon and notification */
-    void createTrayIcon();
+    void createTrayIcon(bool fIsTestnet);
     /** Create system tray menu (or setup the dock menu) */
     void createTrayIconMenu();
 

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -75,7 +75,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "In this mode -genproclimit controls how many blocks are generated "
 "immediately."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Listen for JSON-RPC connections on <port> (default: 9332)"),
+"Listen for JSON-RPC connections on <port> (default: 9332 or testnet: 18332)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Number of seconds to keep misbehaving peers from reconnecting (default: "
 "86400)"),
@@ -141,7 +141,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Cannot write default address"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Clear list of wallet transactions (diagnostic tool; implies -rescan)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Connect only to the specified node(s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Connect through SOCKS proxy"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Connect to JSON-RPC on <port> (default: 9332)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Connect to JSON-RPC on <port> (default: 9332 or testnet: 18332)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Connect to a node to retrieve peer addresses, and disconnect"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Connection options:"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Corrupted block database detected"),
@@ -194,7 +194,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -paytxfee=<amount>: '%s'")
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Limit size of signature cache to <n> entries (default: 50000)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "List commands"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Listen for connections on <port> (default: 11337)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Listen for connections on <port> (default: 11337 or testnet: 14321)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading addresses..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading block index..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading wallet..."),

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -54,7 +54,7 @@ public:
     double getVerificationProgress() const;
     QDateTime getLastBlockDate() const;
 
-    //! Return network (main)
+    //! Return network (main, testnet3, regtest)
     QString getNetworkName() const;
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -44,5 +44,6 @@ static const int MAX_PAYMENT_REQUEST_SIZE = 50000; // bytes
 #define QAPP_ORG_NAME "Smileycoin"
 #define QAPP_ORG_DOMAIN "smileycoin.org"
 #define QAPP_APP_NAME_DEFAULT "Smileycoin-Qt"
+#define QAPP_APP_NAME_TESTNET "Smileycoin-Qt-testnet"
 
 #endif // GUICONSTANTS_H

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -107,7 +107,7 @@ void MacDockIconHandler::setIcon(const QIcon &icon)
         }
 
         if(!image) {
-            // if image could not be created, load std. app icon
+            // if testnet image could not be created, load std. app icon
             image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
         }
     }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -64,7 +64,7 @@ void PaymentServer::freeCertStore()
 
 //
 // Create a name that is unique for:
-//  network
+//  testnet / non-testnet
 //  data directory
 //
 static QString ipcServerName()
@@ -72,6 +72,8 @@ static QString ipcServerName()
     QString name("SmileycoinQt");
 
     // Append a simple hash of the datadir
+    // Note that GetDataDir(true) returns a different path
+    // for -testnet versus main net
     QString ddir(QString::fromStdString(GetDataDir(true).string()));
     name.append(QString::number(qHash(ddir)));
 
@@ -196,7 +198,7 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
                 SelectParams(CChainParams::MAIN);
                 if (!address.IsValid())
                 {
-                    qDebug() << "PaymentServer::ipcSendCommandLine : Address is not valid for MAINNET: " << arg;
+                    SelectParams(CChainParams::TESTNET);
                 }
             }
         }
@@ -210,7 +212,7 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
                 if (request.getDetails().network() == "main")
                     SelectParams(CChainParams::MAIN);
                 else
-                    qDebug() << "PaymentServer::ipcSendCommandLine : Requested network does not exist: " << arg;
+                    SelectParams(CChainParams::TESTNET);
             }
         }
         else

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -63,7 +63,7 @@ public:
     // Returns true if there were URIs on the command line
     // which were successfully sent to an already-running
     // process.
-    // Note: if a payment request is given, SelectParams(MAIN)
+    // Note: if a payment request is given, SelectParams(MAIN/TESTNET)
     // will be called so we startup in the right mode.
     static bool ipcSendCommandLine();
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -15,7 +15,7 @@
 #include <QApplication>
 #include <QPainter>
 
-SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
+SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet) :
     QSplashScreen(pixmap, f)
 {
     setAutoFillBackground(true);
@@ -30,16 +30,22 @@ SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
     float fontFactor            = 1.0;
 
     // define text to place
-    QString titleText       = QString(QApplication::applicationName());
+    QString titleText       = QString(QApplication::applicationName()).replace(QString("-testnet"), QString(""), Qt::CaseSensitive);
     QString versionText     = QString("Version %1 ").arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightText1   = QChar(0xA9)+QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin developers"));
     QString copyrightText2   = QChar(0xA9)+QString(" 2011-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Auroracoin developers"));
+    QString testnetAddText  = QString(tr("[testnet]"));
 
     QString font            = "Arial";
 
     // load the bitmap for writing some text over it
     QPixmap newPixmap;
-    newPixmap     = QPixmap(":/images/splash");
+    if(isTestNet) {
+        newPixmap     = QPixmap(":/images/splash_testnet");
+    }
+    else {
+        newPixmap     = QPixmap(":/images/splash");
+    }
 
     QPainter pixPaint(&newPixmap);
     pixPaint.setPen(QColor(100,100,100));
@@ -70,6 +76,16 @@ SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
     pixPaint.setFont(QFont(font, 9*fontFactor));
     pixPaint.drawText(paddingLeftCol2,paddingTopCol2+line2,copyrightText1);
     pixPaint.drawText(paddingLeftCol2,paddingTopCol2+line3,copyrightText2);
+
+    // draw testnet string if testnet is on
+    if(isTestNet) {
+        QFont boldFont = QFont(font, 3*fontFactor);
+        boldFont.setWeight(QFont::Bold);
+        pixPaint.setFont(boldFont);
+        fm = pixPaint.fontMetrics();
+        int testnetAddTextWidth  = fm.width(testnetAddText);
+        pixPaint.drawText(newPixmap.width()-testnetAddTextWidth-10,15,testnetAddText);
+    }
 
     pixPaint.end();
 

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -14,7 +14,7 @@ class SplashScreen : public QSplashScreen
     Q_OBJECT
 
 public:
-    explicit SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f);
+    explicit SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet);
     ~SplashScreen();
 
 public slots:

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -454,7 +454,7 @@ Value getblockchaininfo(const Array& params, bool fHelp)
             "Returns an object containing various state info regarding block chain processing.\n"
             "\nResult:\n"
             "{\n"
-            "  \"chain\": \"xxxx\",        (string) current chain (main)\n"
+            "  \"chain\": \"xxxx\",        (string) current chain (main, testnet3, regtest)\n"
             "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
             "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
             "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -259,12 +259,15 @@ std::string HelpMessageCli(bool mainProgram)
         strUsage += "  -?                     " + _("This help message") + "\n";
         strUsage += "  -conf=<file>           " + _("Specify configuration file (default: smileycoin.conf)") + "\n";
         strUsage += "  -datadir=<dir>         " + _("Specify data directory") + "\n";
+        strUsage += "  -testnet               " + _("Use the test network") + "\n";
+        strUsage += "  -regtest               " + _("Enter regression test mode, which uses a special chain in which blocks can be "
+                                                    "solved instantly. This is intended for regression testing tools and app development.") + "\n";
     } else {
         strUsage += _("RPC client options:") + "\n";
     }
 
     strUsage += "  -rpcconnect=<ip>       " + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n";
-    strUsage += "  -rpcport=<port>        " + _("Connect to JSON-RPC on <port> (default: 9332)") + "\n";
+    strUsage += "  -rpcport=<port>        " + _("Connect to JSON-RPC on <port> (default: 9332 or testnet: 18332)") + "\n";
     strUsage += "  -rpcwait               " + _("Wait for RPC server to start") + "\n";
 
     if(mainProgram)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -147,6 +147,7 @@ Value setgenerate(const Array& params, bool fHelp)
             "\nArguments:\n"
             "1. generate         (boolean, required) Set to true to turn on generation, off to turn off.\n"
             "2. genproclimit     (numeric, optional) Set the processor limit for when generation is on. Can be -1 for unlimited.\n"
+            "                    Note: in -regtest mode, genproclimit controls how many blocks are generated immediately.\n"
             "\nExamples:\n"
             "\nSet the generation on with a limit of one processor\n"
             + HelpExampleCli("setgenerate", "true 1") +
@@ -173,9 +174,40 @@ Value setgenerate(const Array& params, bool fHelp)
             fGenerate = false;
     }
 
-    mapArgs["-gen"] = (fGenerate ? "1" : "0");
-    mapArgs ["-genproclimit"] = itostr(nGenProcLimit);
-    GenerateBitcoins(fGenerate, pwalletMain, nGenProcLimit);
+    // -regtest mode: don't return until nGenProcLimit blocks are generated
+    if (fGenerate && Params().NetworkID() == CChainParams::REGTEST)
+    {
+        int nHeightStart = 0;
+        int nHeightEnd = 0;
+        int nHeight = 0;
+        int nGenerate = (nGenProcLimit > 0 ? nGenProcLimit : 1);
+        {   // Don't keep cs_main locked
+            LOCK(cs_main);
+            nHeightStart = chainActive.Height();
+            nHeight = nHeightStart;
+            nHeightEnd = nHeightStart+nGenerate;
+        }
+        int nHeightLast = -1;
+        while (nHeight < nHeightEnd)
+        {
+            if (nHeightLast != nHeight)
+            {
+                nHeightLast = nHeight;
+                GenerateBitcoins(fGenerate, pwalletMain, 1);
+            }
+            MilliSleep(1);
+            {   // Don't keep cs_main locked
+                LOCK(cs_main);
+                nHeight = chainActive.Height();
+            }
+        }
+    }
+    else // Not -regtest: start generate thread, return immediately
+    {
+        mapArgs["-gen"] = (fGenerate ? "1" : "0");
+        mapArgs ["-genproclimit"] = itostr(nGenProcLimit);
+        GenerateBitcoins(fGenerate, pwalletMain, nGenProcLimit);
+    }
 
     return Value::null;
 }
@@ -218,6 +250,7 @@ Value getmininginfo(const Array& params, bool fHelp)
             "  \"genproclimit\": n          (numeric) The processor limit for generation. -1 if no generation. (see getgenerate or setgenerate calls)\n"
             "  \"hashespersec\": n          (numeric) The hashes per second of the generation, or 0 if no generation.\n"
             "  \"pooledtx\": n              (numeric) The size of the mem pool\n"
+            "  \"testnet\": true|false      (boolean) If using testnet or not\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmininginfo", "")
@@ -240,6 +273,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("genproclimit",     (int)GetArg("-genproclimit", -1)));
 //    obj.push_back(Pair("networkhashps",    getnetworkhashps(params, false)));
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
+    obj.push_back(Pair("testnet",          TestNet()));
 #ifdef ENABLE_WALLET
     obj.push_back(Pair("generate",         getgenerate(params, false)));
     obj.push_back(Pair("hashespersec",     gethashespersec(params, false)));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -45,6 +45,7 @@ Value getinfo(const Array& params, bool fHelp)
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
             "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
+            "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
             "  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
             "  \"keypoolsize\": xxxx,        (numeric) how many new keys are pre-generated\n"
             "  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
@@ -82,6 +83,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("difficulty_groestl", (double)GetDifficulty(NULL, ALGO_GROESTL)));
     obj.push_back(Pair("difficulty_skein",   (double)GetDifficulty(NULL, ALGO_SKEIN)));
     obj.push_back(Pair("difficulty_qubit",   (double)GetDifficulty(NULL, ALGO_QUBIT)));
+    obj.push_back(Pair("testnet",            TestNet()));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -54,7 +54,7 @@ public:
 class CTxMemPool
 {
 private:
-    bool fSanityCheck; // Normally false, true if -checkmempool
+    bool fSanityCheck; // Normally false, true if -checkmempool or -regtest
     unsigned int nTransactionsUpdated;
 
 public:


### PR DESCRIPTION
This reverts commits 7af785ea9612d03372bf058583053052f9f97805 and c0cd235502645f56eac4fa808e7170a6cbe9854b

There are a few bits still commented out from before the first git log which still remain a mystery to me on how it works
but I've tested it a bit and it seems to work decently.

In order to test properly you'll need to manually add a node, you can issue
`smileycoin-cli addnode broslaugin.com:12337 onetry` and that should connect to a testnet wallet I'm running. If it's down or you want to run it in isolation, run another instance of the testnet wallet and connect the two via `addnode`. Run `smileycoind` with either the `-testnet` flag or add `testnet=1` to `~/.smileycoin/smileycoin.conf`

Things that need fixing before merge:
* CDNSSeed is set to localhost and needs it's own entry. I suggested to @gstefans that **testnet.smileyco.in** could be used
* Check if regtest mode works and if we can maybe start building with unit tests now
* Bikeshed bas58prefixes, I just changed it to some value, currently P2PKH addresses start with Q and P2SH start with 5, I don't have any preference here
* Generally more eyes on this PR would be helpful 