### PR TITLE
Add github action for building the wallet

### DIFF
--- a/.github/workflows/smileycoin-ci.yml
+++ b/.github/workflows/smileycoin-ci.yml
@@ -1,0 +1,25 @@
+name: SmileyCoin CI build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ubuntu_no_gui:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential libdb5.3++-dev libboost-all-dev libssl-dev libtool autoconf pkg-config
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./autogen.sh && ./configure --with-gui=no
+    - name: make
+      run: make
+    - name: make check
+      run: make check


### PR DESCRIPTION
This enables automatic builds on github on master and all pull requests made against master.

Notes:
* Base build only, explicitly set `--with-gui=no` and no GUI deps are being pulled
* We could possibly use the cache action to cache the dependencies but I haven't looked into that much
* Possibility of adding more jobs where we build the qt wallet as well as well as testing builds on MacOS, Windows, *BSD etc.
* Skipping `make distcheck` for now as it is not working in the repo anyhow