### PR TITLE
build: Update find_bdb macros

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -1,66 +1,78 @@
+dnl Copyright (c) 2013-2015 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 AC_DEFUN([BITCOIN_FIND_BDB48],[
-  AC_MSG_CHECKING([for Berkeley DB C++ headers])
-  BDB_CPPFLAGS=
-  BDB_LIBS=
-  bdbpath=X
-  bdb48path=X
-  bdbdirlist=
-  for _vn in 4.8 48 4 5 ''; do
-    for _pfx in b lib ''; do
-      bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+  AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
+  AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
+
+  if test "x$BDB_CFLAGS" = "x"; then
+    AC_MSG_CHECKING([for Berkeley DB C++ headers])
+    BDB_CPPFLAGS=
+    bdbpath=X
+    bdb48path=X
+    bdbdirlist=
+    for _vn in 4.8 48 4 5 5.3 ''; do
+      for _pfx in b lib ''; do
+        bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+      done
     done
-  done
-  for searchpath in $bdbdirlist ''; do
-    test -n "${searchpath}" && searchpath="${searchpath}/"
-    AC_TRY_COMPILE([
-      #include <${searchpath}db_cxx.h>
-    ],[
-      #if !((DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 8) || DB_VERSION_MAJOR > 4)
-        #error "failed to find bdb 4.8+"
-      #endif
-    ],[
-      if test "x$bdbpath" = "xX"; then
-        bdbpath="${searchpath}"
-      fi
-    ],[
-      continue
-    ])
-    AC_TRY_COMPILE([
-      #include <${searchpath}db_cxx.h>
-    ],[
-      #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
-        #error "failed to find bdb 4.8"
-      #endif
-    ],[
-      bdb48path="${searchpath}"
-      break
-    ])
-  done
-  if test "x$bdbpath" = "xX"; then
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR(libdb_cxx headers missing)
-  elif test "x$bdb48path" = "xX"; then
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
-      AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
-    ],[
-      AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore)])
-    ])
+    for searchpath in $bdbdirlist ''; do
+      test -n "${searchpath}" && searchpath="${searchpath}/"
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !((DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 8) || DB_VERSION_MAJOR > 4)
+          #error "failed to find bdb 4.8+"
+        #endif
+      ]])],[
+        if test "x$bdbpath" = "xX"; then
+          bdbpath="${searchpath}"
+        fi
+      ],[
+        continue
+      ])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
+          #error "failed to find bdb 4.8"
+        #endif
+      ]])],[
+        bdb48path="${searchpath}"
+        break
+      ],[])
+    done
+    if test "x$bdbpath" = "xX"; then
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    elif test "x$bdb48path" = "xX"; then
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
+      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
+        AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
+      ],[
+        AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
+      ])
+    else
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
+      bdbpath="${bdb48path}"
+    fi
   else
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
-    bdbpath="${bdb48path}"
+    BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
   AC_SUBST(BDB_CPPFLAGS)
   
-  # TODO: Ideally this could find the library version and make sure it matches the headers being used
-  for searchlib in db_cxx-4.8 db_cxx; do
-    AC_CHECK_LIB([$searchlib],[main],[
-      BDB_LIBS="-l${searchlib}"
-      break
-    ])
-  done
   if test "x$BDB_LIBS" = "x"; then
-      AC_MSG_ERROR(libdb_cxx missing)
+    # TODO: Ideally this could find the library version and make sure it matches the headers being used
+    for searchlib in db_cxx-4.8 db_cxx db4_cxx; do
+      AC_CHECK_LIB([$searchlib],[main],[
+        BDB_LIBS="-l${searchlib}"
+        break
+      ])
+    done
+    if test "x$BDB_LIBS" = "x"; then
+        AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    fi
   fi
   AC_SUBST(BDB_LIBS)
 ])

--- a/build-aux/m4/smileycoin_find_bdb53.m4
+++ b/build-aux/m4/smileycoin_find_bdb53.m4
@@ -1,66 +1,78 @@
+dnl Copyright (c) 2013-2015 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 AC_DEFUN([SMILEYCOIN_FIND_BDB53],[
-  AC_MSG_CHECKING([for Berkeley DB C++ headers])
-  BDB_CPPFLAGS=
-  BDB_LIBS=
-  bdbpath=X
-  bdb53path=X
-  bdbdirlist=
-  for _vn in 5.3 53 5 ''; do
-    for _pfx in b lib ''; do
-      bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+  AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
+  AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
+
+  if test "x$BDB_CFLAGS" = "x"; then
+    AC_MSG_CHECKING([for Berkeley DB C++ headers])
+    BDB_CPPFLAGS=
+    bdbpath=X
+    bdb53path=X
+    bdbdirlist=
+    for _vn in 5.3 53 5 ''; do
+      for _pfx in b lib ''; do
+        bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+      done
     done
-  done
-  for searchpath in $bdbdirlist ''; do
-    test -n "${searchpath}" && searchpath="${searchpath}/"
-    AC_TRY_COMPILE([
-      #include <${searchpath}db_cxx.h>
-    ],[
-      #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
-        #error "failed to find bdb 5.3+"
-      #endif
-    ],[
-      if test "x$bdbpath" = "xX"; then
-        bdbpath="${searchpath}"
-      fi
-    ],[
-      continue
-    ])
-    AC_TRY_COMPILE([
-      #include <${searchpath}db_cxx.h>
-    ],[
-      #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
-        #error "failed to find bdb 5.3"
-      #endif
-    ],[
-      bdb53path="${searchpath}"
-      break
-    ])
-  done
-  if test "x$bdbpath" = "xX"; then
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR(libdb_cxx headers missing)
-  elif test "x$bdb53path" = "xX"; then
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
-      AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
-    ],[
-      AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore)])
-    ])
+    for searchpath in $bdbdirlist ''; do
+      test -n "${searchpath}" && searchpath="${searchpath}/"
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
+          #error "failed to find bdb 5.3+"
+        #endif
+      ]])],[
+        if test "x$bdbpath" = "xX"; then
+          bdbpath="${searchpath}"
+        fi
+      ],[
+        continue
+      ])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
+          #error "failed to find bdb 5.3"
+        #endif
+      ]])],[
+        bdb53path="${searchpath}"
+        break
+      ],[])
+    done
+    if test "x$bdbpath" = "xX"; then
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    elif test "x$bdb53path" = "xX"; then
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
+      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
+        AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
+      ],[
+        AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
+      ])
+    else
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
+      bdbpath="${bdb53path}"
+    fi
   else
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
-    bdbpath="${bdb53path}"
+    BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
   AC_SUBST(BDB_CPPFLAGS)
   
-  # TODO: Ideally this could find the library version and make sure it matches the headers being used
-  for searchlib in db_cxx-5.3 db_cxx; do
-    AC_CHECK_LIB([$searchlib],[main],[
-      BDB_LIBS="-l${searchlib}"
-      break
-    ])
-  done
   if test "x$BDB_LIBS" = "x"; then
-      AC_MSG_ERROR(libdb_cxx missing)
+    # TODO: Ideally this could find the library version and make sure it matches the headers being used
+    for searchlib in db_cxx-5.3 db_cxx db5_cxx; do
+      AC_CHECK_LIB([$searchlib],[main],[
+        BDB_LIBS="-l${searchlib}"
+        break
+      ])
+    done
+    if test "x$BDB_LIBS" = "x"; then
+        AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    fi
   fi
   AC_SUBST(BDB_LIBS)
 ])


### PR DESCRIPTION
This pulls in the current `bitcoin_find_bdb48.m4` from litecoin and modifies the
`smileycoin_find_bdb53.m4` to match, making the `BDB_LIBS` and `BDB_CPPFLAGS`
vars available.

Closes: #44 