### PR TITLE
Fix compilation errors on linux, add QPainterPath dependency

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -16,6 +16,7 @@
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
+#include <QPainterPath>
 
 #define DECORATION_SIZE 64
 #define NUM_ITEMS 3

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -14,6 +14,7 @@
 
 #include <QApplication>
 #include <QPainter>
+#include <QPainterPath>
 
 SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet) :
     QSplashScreen(pixmap, f)

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
I had issues trying to compile on linux, so I made these changes to get it to compile.
During compilation it would throw an error about the **-fPIE** flag being used:

>  error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)."
 error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "\

setting it to **-fPIC**, just as it is set elsewhere in the makefile fixes this.



QT complained about QPainterPath as a missing dependency, adding this resolved that issue. 

Let me know if this needs any changes before merge.