### PR TITLE
Task 9: Added 'gethex' command to smileycoin-cli.

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "string"
 #include "base58.h"
 #include "init.h"
 #include "main.h"
@@ -486,6 +487,33 @@ Value verifymessage(const Array& params, bool fHelp)
         return false;
 
     return (pubkey.GetID() == keyID);
+}
+
+Value gethex(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+	    "gethex \"string\" \n"
+	    "\n Returns the hex value for a given ascii input string.\n"
+	    "\n Arguments: \n"
+	    "\n 1. \"string\" (string, required) The input string in ascii encoding to be converted to hex code.\n"
+
+	    "\n Result: \n"
+	    "\n \"hex\" (string)  The hex code of the input.\n"
+        );
+
+    string strInput = params[0].get_str();
+
+    static const char hex_digits[] = "0123456789ABCDEF";
+
+    std::string output;
+    output.reserve(strInput.length()*2);
+    for (unsigned char c : strInput)
+    {
+        output.push_back(hex_digits[c >> 4]);
+	output.push_back(hex_digits[c & 15]);
+    }
+    return output;
 }
 
 #pragma clang diagnostic pop

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -271,6 +271,7 @@ static const CRPCCommand vRPCCommands[] =
     { "createmultisig",         &createmultisig,         true,      true ,      false },
     { "validateaddress",        &validateaddress,        true,      false,      false }, /* uses wallet if enabled */
     { "verifymessage",          &verifymessage,          false,     false,      false },
+    { "gethex",          	&gethex,                 false,     false,      false },
 
 #ifdef ENABLE_WALLET
     /* Wallet */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -203,5 +203,6 @@ extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gethex(const json_spirit::Array& params, bool fHelp);
 
 #endif


### PR DESCRIPTION
Takes a regular string input and returns the hex value.

(Possibly) Useful for quickly generating hex value for data field in 'createrawtransaction'.
This was made for Task 9 in STÆ532M.