### PR TITLE
Implement Tab-completion in the RPC console

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -240,6 +240,16 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
                 return true;
             }
             break;
+
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            //TODO: fix variable names
+            if(obj == autoCompleter->popup()) {
+                QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+                return true;
+            }
+            break;
+
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
             // Exclude most combinations and keys that emit no text, except paste shortcuts
@@ -280,6 +290,21 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->startupTime->setText(model->formatClientStartupTime());
 
         ui->networkName->setText(model->getNetworkName());
+
+        //TODO: variable names
+        //Completion
+        QStringList wordList;
+        std::vector<std::string> commandList = tableRPC.listCommands();
+        for (size_t i = 0; i < commandList.size(); ++i)
+        {
+            wordList << commandList[i].c_str();
+        }
+
+        autoCompleter = new QCompleter(wordList, this);
+        ui->lineEdit->setCompleter(autoCompleter);
+
+        // clear the lineEdit after activating from QCompleter
+        autoCompleter->popup()->installEventFilter(this);
     }
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -32,9 +32,9 @@ const struct {
     const char *source;
 } ICON_MAPPING[] = {
     {"cmd-request", ":/icons/tx_input"},
-    {"cmd-reply", ":/icons/tx_output"},
-    {"cmd-error", ":/icons/tx_output"},
-    {"misc", ":/icons/tx_inout"},
+    {"cmd-reply",   ":/icons/tx_output"},
+    {"cmd-error",   ":/icons/tx_output"},
+    {"misc",        ":/icons/tx_inout"},
     {NULL, NULL}
 };
 
@@ -87,7 +87,7 @@ bool parseCommandLine(std::vector<std::string> &args, const std::string &strComm
         case STATE_EATING_SPACES: // Handle runs of whitespace
             switch(ch)
             {
-            case '"': state = STATE_DOUBLEQUOTED; break;
+            case '"':  state = STATE_DOUBLEQUOTED; break;
             case '\'': state = STATE_SINGLEQUOTED; break;
             case '\\': state = STATE_ESCAPE_OUTER; break;
             case ' ': case '\n': case '\t':
@@ -230,8 +230,8 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
         Qt::KeyboardModifiers mod = keyevt->modifiers();
         switch(key)
         {
-        case Qt::Key_Up: if(obj == ui->lineEdit) { browseHistory(-1); return true; } break;
-        case Qt::Key_Down: if(obj == ui->lineEdit) { browseHistory(1); return true; } break;
+        case Qt::Key_Up:   if(obj == ui->lineEdit) { browseHistory(-1); return true; } break;
+        case Qt::Key_Down: if(obj == ui->lineEdit) { browseHistory(1);  return true; } break;
         case Qt::Key_PageUp: /* pass paging keys to messages widget */
         case Qt::Key_PageDown:
             if(obj == ui->lineEdit)
@@ -255,8 +255,8 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
             // Exclude most combinations and keys that emit no text, except paste shortcuts
             if(obj == ui->messagesWidget && (
                   (!mod && !keyevt->text().isEmpty() && key != Qt::Key_Tab) ||
-                  ((mod & Qt::ControlModifier) && key == Qt::Key_V) ||
-                  ((mod & Qt::ShiftModifier) && key == Qt::Key_Insert)))
+                  ((mod &  Qt::ControlModifier)      && key == Qt::Key_V)   ||
+                  ((mod &  Qt::ShiftModifier)        && key == Qt::Key_Insert)))
             {
                 ui->lineEdit->setFocus();
                 QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
@@ -312,10 +312,10 @@ static QString categoryClass(int category)
 {
     switch(category)
     {
-    case RPCConsole::CMD_REQUEST:  return "cmd-request"; break;
-    case RPCConsole::CMD_REPLY:    return "cmd-reply"; break;
-    case RPCConsole::CMD_ERROR:    return "cmd-error"; break;
-    default:                       return "misc";
+    case RPCConsole::CMD_REQUEST: return "cmd-request";
+    case RPCConsole::CMD_REPLY:   return "cmd-reply";
+    case RPCConsole::CMD_ERROR:   return "cmd-error";
+    default:                      return "misc";
     }
 }
 
@@ -381,7 +381,7 @@ void RPCConsole::setNumConnections(int count)
         return;
 
     QString connections = QString::number(count) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
+    connections += tr("In:")  + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN))  + " / ";
     connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
 
     ui->numberOfConnections->setText(connections);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -243,12 +243,33 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
 
         case Qt::Key_Return:
         case Qt::Key_Enter:
-            //TODO: fix variable names
-            if(obj == autoCompleter->popup()) {
+            if(obj == autoCompleter->popup())
+            {
                 QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
                 return true;
             }
             break;
+
+        case Qt::Key_Tab:
+        case Qt::Key_Backtab:
+                // Provides tab completion in the console
+                if (obj == autoCompleter->popup())
+                {
+                    QModelIndex curIndex = autoCompleter->popup()->currentIndex();
+                    QModelIndex newIndex;
+
+                    if (curIndex.row() == -1)
+                        newIndex = autoCompleter->popup()->model()->index(0, 0);
+                    else if(key == Qt::Key_Backtab)
+                        newIndex = autoCompleter->popup()->model()->index(curIndex.row() - 1, curIndex.column());
+                    else
+                        newIndex = autoCompleter->popup()->model()->index(curIndex.row() + 1, curIndex.column());
+
+                    autoCompleter->popup()->setCurrentIndex(newIndex);
+
+                    return true;
+                }
+                break;
 
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
@@ -291,7 +312,6 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         ui->networkName->setText(model->getNetworkName());
 
-        //TODO: variable names
         //Completion
         QStringList wordList;
         std::vector<std::string> commandList = tableRPC.listCommands();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -6,6 +6,7 @@
 #define RPCCONSOLE_H
 
 #include <QDialog>
+#include <QCompleter>
 
 class ClientModel;
 
@@ -73,6 +74,8 @@ private:
     int historyPtr;
 
     void startExecutor();
+
+    QCompleter *autoCompleter;
 };
 
 #endif // RPCCONSOLE_H

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -931,6 +931,16 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
     }
 }
 
+std::vector <std::string> CRPCTable::listCommands() const {
+    std::vector <std::string> commandList;
+    typedef std::map<std::string, const CRPCCommand *> commandMap;
+
+    std::transform(mapCommands.begin(), mapCommands.end(),
+            std::back_inserter(commandList),
+            boost::bind(&commandMap::value_type::first, _1));
+    return commandList;
+}
+
 std::string HelpExampleCli(string methodname, string args){
     return "> smileycoin-cli " + methodname + " " + args + "\n";
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -85,6 +85,7 @@ public:
     CRPCTable();
     const CRPCCommand* operator[](std::string name) const;
     std::string help(std::string name) const;
+    std::vector<std::string> listCommands() const;
 
     /**
      * Execute a method.


### PR DESCRIPTION
This PR implements tab-completion in the RPC-console for smileyCoin. 
The user can type a few letters of a command for the console causing a menu to pop up, the user can then choose to complete the word using the tab key. 
Shift-tab works as well to select backwards in the menu.
Some formatting was addressed as well, and redundant use of breaks was removed.

Part of Lokaverkefni in Rafmyntir course along with PRs #77 #76 #75 
HI username: hrs70