### PR TITLE
Compiler warning fix

### DIFF
--- a/src/regex.h
+++ b/src/regex.h
@@ -44,7 +44,7 @@ bool isRegex(const string& txData) {
         lines.push_back(line);
     }
 
-    for (int i = 0; i < lines.size(); i++) {
+    for (size_t i = 0; i < lines.size(); i++) {
         std::string strengur = lines[i];
         std::regex expr(strengur);
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -855,7 +855,6 @@ Value getubilist(const Array& params, bool fHelp)
 
     ServiceItemList.GetUbiList(info);
 
-    int i = 0;
     
     for(std::set< std::pair< std::string, std::tuple<std::string, std::string> > >::const_iterator it = info.begin(); it!=info.end(); it++ )
     {

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -874,18 +874,18 @@ Value getdexlist(const Array& params, bool fHelp)
         throw runtime_error("getdexlist \"address\"\n"
                             "Returns all DEX addresses that belong to the specified DEX service address\n"
                             );
-    
+
     Object obj;
     std::multiset<std::pair< std::string, std::tuple<std::string, std::string, std::string>>> info;
 
     ServiceItemList.GetDexList(info);
-    
+
     for(std::set< std::pair< std::string, std::tuple<std::string, std::string, std::string> > >::const_iterator it = info.begin(); it!=info.end(); it++ )
     {
         obj.push_back(Pair("DEX Address: ", it->first));
         obj.push_back(Pair("Description: ", get<2>(it->second)));
     }
-    
+
     return obj;
 }
 
@@ -896,18 +896,18 @@ Value getnpolist(const Array& params, bool fHelp)
         throw runtime_error("getnpolist\n"
                             "Returns all non profit organization addresses\n"
                             );
-    
+
     Object obj;
     /*std::multiset<std::pair< CScript, std::tuple<std::string, std::string, std::string>>> info;
 
     ServiceItemList.GetNpoList(info);
-    
+
     for(std::set< std::pair< CScript, std::tuple<std::string, std::string, std::string> > >::const_iterator it = info.begin(); it!=info.end(); it++ )
     {
         obj.push_back(Pair("Npo name: ", get<1>(it->second)));
         obj.push_back(Pair("Npo address: ", get<2>(it->second)));
     }*/
-    
+
     return obj;
 }
 
@@ -918,18 +918,18 @@ Value getbooklist(const Array& params, bool fHelp)
         throw runtime_error("getbooklist \"address\"\n"
                             "Returns all book chapters that belong to the specified book service address\n"
                             );
-    
+
     Object obj;
     std::multiset<std::pair<std::string, std::tuple<std::string, std::string, std::string>>> info;
     ServiceItemList.GetBookList(info);
-    
+
     //TODO bæta við book name, book author og year
     for(std::set< std::pair< std::string, std::tuple<std::string, std::string, std::string> > >::const_iterator it = info.begin(); it!=info.end(); it++ )
     {
         obj.push_back(Pair("Chapter Number: ", get<2>(it->second)));
         obj.push_back(Pair("Chapter Address: ", it->first));
     }
-    
+
     return obj;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -262,8 +262,7 @@ inline bool is_number(std::string s)
 
 inline bool is_date(std::string s)
 {
-    std::string date = "([1-9]|([012][0-9])|(3[01]))\/([0]{0,1}[1-9]|1[012])\/[0-9]{4}(([01]{0,1}[0-9])|(2[0-4])):[0-5][0-9]";
-    std::regex expr(date);
+    std::regex expr(R"--(([1-9]|([012][0-9])|(3[01]))\/([0]{0,1}[1-9]|1[012])\/[0-9]{4}(([01]{0,1}[0-9])|(2[0-4])):[0-5][0-9])--");
     if (std::regex_match(s, expr)) {
         return true;
     }

--- a/src/util.h
+++ b/src/util.h
@@ -273,17 +273,18 @@ inline bool is_before(std::string dateOfTicket)
 {
     time_t now = time(NULL);
     time_t tTicket;
-    int yy, month, dd, hh, mm;
-    struct tm whenTicket = {0};
+    struct tm whenTicket;
+    memset(&whenTicket, 0, sizeof(struct tm));
     const char *zTicket = dateOfTicket.c_str();
-
-    sscanf(zTicket, "%2d/%2d/%4d %2d:%2d", &dd, &month, &yy, &hh, &mm);
-    whenTicket.tm_mday = dd;
-    whenTicket.tm_mon = month - 1;
-    whenTicket.tm_year = yy - 1900;
-    whenTicket.tm_hour = hh;
-    whenTicket.tm_min = mm;
     whenTicket.tm_isdst = -1;
+
+    sscanf(zTicket, "%2d/%2d/%4d %2d:%2d",
+            &whenTicket.tm_mday,
+            &whenTicket.tm_mon,
+            &whenTicket.tm_year,
+            &whenTicket.tm_hour,
+            &whenTicket.tm_min
+          );
 
     tTicket = mktime(&whenTicket);
 


### PR DESCRIPTION
This PR fixes several compiler warning in order to reduce logspam.

The compiler was complaining about unused variables, this was fixed by removing said variable. 

The compiler was frequently yelling about uninitialized structs, this was fixed by refactoring some code and explicitly filling the struct using memset. 

The compiler complained about unsigned comparison, the integer that was being used was changed to a size_t.

Some whitespace issues were fixed. 
The compiler complained about unknown characters in a regex, this is fixed by using a raw string for the regex.

Part of Lokaverkefni in Rafmyntir 
HI username: hrs70