### PR TITLE
Fix windows crosscompile target and allow manual builds of master

### DIFF
--- a/.github/workflows/smileycoin-ci.yml
+++ b/.github/workflows/smileycoin-ci.yml
@@ -1,6 +1,8 @@
 name: SmileyCoin CI build
 
 on:
+  workflow_dispatch:
+    branches: [ master ]
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/smileycoin-ci.yml
+++ b/.github/workflows/smileycoin-ci.yml
@@ -77,5 +77,5 @@ jobs:
       with:
         name: smileycoin-${{ env.SMLY_PACKAGE_VERSION }}-win64-setup
         path: |
-          ${{ github.workspace }}/smileycoin-$SMLY_PACKAGE_VERSION-win64-setup.exe
+          ${{ github.workspace }}/smileycoin-${{ env.SMLY_PACKAGE_VERSION }}-win64-setup.exe
           ${{ github.workspace }}/SHA256


### PR DESCRIPTION
Adds a manual run button on the workflow under GitHub Actions.
The setup file wasn't found in the upload artifact action as it was still using the deprecated  env variables.
Any PRs should now also build and upload the installer.