### PR TITLE
Remove getwork, add CMutableTransaction and move CMerkleTx to wallet.cpp/h

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -45,7 +45,7 @@ public:
 
         // Build the genesis block.
         const char* pszTimestamp = "NY Times 18/Aug/2014 Bitcoin's Price Falls 12%, to Lowest Value Since May";
-        CTransaction txNew;
+        CMutableTransaction txNew;
         txNew.vin.resize(1);
         txNew.vout.resize(1);
         txNew.vin[0].scriptSig = CScript() << 486604799 << CBigNum(4) << vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -5,6 +5,7 @@
 
 #include "core.h"
 
+#include "hash.h"
 #include "util.h"
 
 std::string COutPoint::ToString() const
@@ -72,38 +73,32 @@ void CTxOut::print() const
     LogPrintf("%s\n", ToString());
 }
 
-uint256 CTransaction::GetHash() const
+CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {}
+
+uint256 CMutableTransaction::GetHash() const
 {
     return SerializeHash(*this);
 }
 
-bool CTransaction::IsNewerThan(const CTransaction& old) const
+void CTransaction::UpdateHash() const
 {
-    if (vin.size() != old.vin.size())
-        return false;
-    for (unsigned int i = 0; i < vin.size(); i++)
-        if (vin[i].prevout != old.vin[i].prevout)
-            return false;
+    *const_cast<uint256*>(&hash) = SerializeHash(*this);
+}
 
-    bool fNewer = false;
-    unsigned int nLowest = std::numeric_limits<unsigned int>::max();
-    for (unsigned int i = 0; i < vin.size(); i++)
-    {
-        if (vin[i].nSequence != old.vin[i].nSequence)
-        {
-            if (vin[i].nSequence <= nLowest)
-            {
-                fNewer = false;
-                nLowest = vin[i].nSequence;
-            }
-            if (old.vin[i].nSequence < nLowest)
-            {
-                fNewer = true;
-                nLowest = old.vin[i].nSequence;
-            }
-        }
-    }
-    return fNewer;
+CTransaction::CTransaction() : hash(0), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
+
+CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {
+    UpdateHash();
+}
+
+CTransaction& CTransaction::operator=(const CTransaction &tx) {
+    *const_cast<int*>(&nVersion) = tx.nVersion;
+    *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
+    *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
+    *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
+    *const_cast<uint256*>(&hash) = tx.hash;
+    return *this;
 }
 
 int64_t CTransaction::GetValueOut() const

--- a/src/core.h
+++ b/src/core.h
@@ -225,48 +225,56 @@ public:
     void print() const;
 };
 
+struct CMutableTransaction;
 
 //The basic transaction that is broadcasted on the network and contained in blocks.
 class CTransaction
 {
+private:
+    /** Memory only. */
+    const uint256 hash;
+    void UpdateHash() const;
+
 public:
     static int64_t nMinTxFee;
     static int64_t nMinRelayTxFee;
     static const int CURRENT_VERSION=1;
-    int nVersion;
-    std::vector<CTxIn> vin;
-    std::vector<CTxOut> vout;
-    unsigned int nLockTime;
 
-    CTransaction()
-    {
-        SetNull();
-    }
+    // The local variables are made const to prevent unintended modification
+    // without updating the cached hash value. However, CTransaction is not
+    // actually immutable; deserialization and assignment are implemented,
+    // and bypass the constness. This is safe, as they update the entire
+    // structure, including the hash.
+    const int nVersion;
+    const std::vector<CTxIn> vin;
+    const std::vector<CTxOut> vout;
+    const unsigned int nLockTime;
 
-    IMPLEMENT_SERIALIZE
-    (
-        READWRITE(this->nVersion);
+    /** Construct a  CTransaction that qualifies as IsNull() */
+    CTransaction();
+
+    /** Convert a  CMutableTransaction into a CTransaction*/
+    CTransaction(const CMutableTransaction &tx);
+
+    CTransaction& operator=(const CTransaction& tx);
+
+    IMPLEMENT_SERIALIZE (
+        READWRITE(*const_cast<int*>(&this->nVersion));
         nVersion = this->nVersion;
-        READWRITE(vin);
-        READWRITE(vout);
-        READWRITE(nLockTime);
+        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
+        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
+        READWRITE(*const_cast<unsigned int*>(&nLockTime));
+        if (fRead)
+            UpdateHash();
     )
 
-    void SetNull()
-    {
-        nVersion = CTransaction::CURRENT_VERSION;
-        vin.clear();
-        vout.clear();
-        nLockTime = 0;
+    bool IsNull() const {
+        return vin.empty() && vout.empty();
     }
 
-    bool IsNull() const
-    {
-        return (vin.empty() && vout.empty());
+    const uint256 GetHash() const {
+        return hash;
     }
-
-    uint256 GetHash() const;
-    bool IsNewerThan(const CTransaction& old) const;
 
     // Return sum of txouts.
     int64_t GetValueOut() const;
@@ -282,20 +290,42 @@ public:
 
     friend bool operator==(const CTransaction& a, const CTransaction& b)
     {
-        return (a.nVersion  == b.nVersion &&
-                a.vin       == b.vin &&
-                a.vout      == b.vout &&
-                a.nLockTime == b.nLockTime);
+        return a.hash == b.hash;
     }
 
     friend bool operator!=(const CTransaction& a, const CTransaction& b)
     {
-        return !(a == b);
+        return a.hash != b.hash;
     }
 
 
     std::string ToString() const;
     void print() const;
+};
+
+/** A mutable version of CTransaction. */
+struct CMutableTransaction
+{
+    int nVersion;
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    unsigned int nLockTime;
+
+    CMutableTransaction();
+    CMutableTransaction(const CTransaction &tx);
+
+    IMPLEMENT_SERIALIZE(
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(vin);
+        READWRITE(vout);
+        READWRITE(nLockTime);
+    )
+
+    /** Compute the hash of this CMutableTransaction. This is computed on the
+     * fly, as opposed to GetHash() in CTransaction, which uses a cached result.
+     */
+    uint256 GetHash() const;
 };
 
 //Wrapper for CTxOut that provides a more compact serialization

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -125,7 +125,6 @@ void Shutdown()
     RenameThread("bitcoin-shutoff");
     mempool.AddTransactionsUpdated(1);
     StopRPCThreads();
-    ShutdownRPCMining();
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         bitdb.Flush(false);
@@ -1275,8 +1274,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
 
     StartNode(threadGroup);
-    // InitRPCMining is needed here so getwork/getblocktemplate in the GUI debug console works properly.
-    InitRPCMining();
     if (fServer)
         StartRPCThreads();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -685,54 +685,6 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, CCoinsViewCache& inputs)
 	return nSigOps;
 }
 
-int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
-{
-	AssertLockHeld(cs_main);
-	CBlock blockTmp;
-
-	if (pblock == NULL) {
-		CCoins coins;
-		if (pcoinsTip->GetCoins(GetHash(), coins)) {
-			CBlockIndex *pindex = chainActive[coins.nHeight];
-			if (pindex) {
-				if (!ReadBlockFromDisk(blockTmp, pindex))
-					return 0;
-				pblock = &blockTmp;
-			}
-		}
-	}
-
-	if (pblock) {
-		// Update the tx's hashBlock
-		hashBlock = pblock->GetHash();
-
-		// Locate the transaction
-		for (nIndex = 0; nIndex < (int)pblock->vtx.size(); nIndex++)
-			if (pblock->vtx[nIndex] == *(CTransaction*)this)
-				break;
-		if (nIndex == (int)pblock->vtx.size())
-		{
-			vMerkleBranch.clear();
-			nIndex = -1;
-			LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
-			return 0;
-		}
-
-		// Fill in merkle branch
-		vMerkleBranch = pblock->GetMerkleBranch(nIndex);
-	}
-
-	// Is the tx in a block that's in the main chain
-	map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashBlock);
-	if (mi == mapBlockIndex.end())
-		return 0;
-	CBlockIndex* pindex = (*mi).second;
-	if (!pindex || !chainActive.Contains(pindex))
-		return 0;
-
-	return chainActive.Height() - pindex->nHeight + 1;
-}
-
 bool CheckTransaction(const CTransaction& tx, CValidationState &state)
 {
 	// Basic checks that don't depend on any context
@@ -964,56 +916,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 	g_signals.SyncTransaction(hash, tx, NULL);
 
 	return true;
-}
-
-
-int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
-{
-	if (hashBlock == 0 || nIndex == -1)
-		return 0;
-	AssertLockHeld(cs_main);
-
-	// Find the block it claims to be in
-	map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashBlock);
-	if (mi == mapBlockIndex.end())
-		return 0;
-	CBlockIndex* pindex = (*mi).second;
-	if (!pindex || !chainActive.Contains(pindex))
-		return 0;
-
-	// Make sure the merkle branch connects to this block
-	if (!fMerkleVerified)
-	{
-		if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
-			return 0;
-		fMerkleVerified = true;
-	}
-
-	pindexRet = pindex;
-	return chainActive.Height() - pindex->nHeight + 1;
-}
-
-int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
-{
-	AssertLockHeld(cs_main);
-	int nResult = GetDepthInMainChainINTERNAL(pindexRet);
-	if (nResult == 0 && !mempool.exists(GetHash()))
-		return -1; // Not in chain, not in mempool
-
-	return nResult;
-}
-
-int CMerkleTx::GetBlocksToMaturity(int nHeight) const
-{
-	if (!IsCoinBase())
-		return 0;
-	return max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
-}
-
-bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree)
-{
-	CValidationState state;
-	return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, NULL);
 }
 
 static unsigned int GetMaxBlockSize(unsigned int height)

--- a/src/main.h
+++ b/src/main.h
@@ -430,66 +430,6 @@ public:
     }
 };
 
-/** A transaction with a merkle branch linking it to the block chain. */
-class CMerkleTx : public CTransaction
-{
-private:
-    int GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const;
-
-public:
-    uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
-    int nIndex;
-
-    // memory only
-    mutable bool fMerkleVerified;
-
-
-    CMerkleTx()
-    {
-        Init();
-    }
-
-    CMerkleTx(const CTransaction& txIn) : CTransaction(txIn)
-    {
-        Init();
-    }
-
-    void Init()
-    {
-        hashBlock = 0;
-        nIndex = -1;
-        fMerkleVerified = false;
-    }
-
-
-    IMPLEMENT_SERIALIZE
-    (
-        nSerSize += SerReadWrite(s, *(CTransaction*)this, nType, nVersion, ser_action);
-        nVersion = this->nVersion;
-        READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
-        READWRITE(nIndex);
-    )
-
-
-    int SetMerkleBranch(const CBlock* pblock=NULL);
-
-    // Return depth of transaction in blockchain:
-    // -1  : not in blockchain, and not in memory pool (conflicted transaction)
-    //  0  : in memory pool, waiting to be included in a block
-    // >=1 : this many blocks deep in the main chain
-    int GetDepthInMainChain(CBlockIndex* &pindexRet) const;
-    int GetDepthInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
-    bool IsInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
-    int GetBlocksToMaturity(int nHeight) const;
-    bool AcceptToMemoryPool(bool fLimitFree=true);
-};
-
-
-
-
-
 /** Data structure that represents a partial merkle tree.
  *
  * It respresents a subset of the txid's of a known block, in a way that

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -10,6 +10,7 @@
 #include "main.h"
 #include "net.h"
 #include "richlistdb.h"
+#include "script.h"
 #ifdef ENABLE_WALLET
 #include "wallet.h"
 #endif
@@ -150,13 +151,15 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, int algo)
   }
 
     // Create coinbase tx
-    CTransaction txNew;
+    CMutableTransaction txNew;
 
     txNew.vin.resize(1);
     txNew.vin[0].prevout.SetNull();
     txNew.vout.resize(1);
     txNew.vout[0].scriptPubKey = scriptPubKeyIn;
-    pblock->vtx.push_back(txNew);
+
+    // Add dummy coinbase tx as first transaction
+    pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 
@@ -365,8 +368,9 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, int algo)
     nLastBlockSize = nBlockSize;
     LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);
 
-  
+
       txNew.vout[0].nValue = GetBlockValue(pindexPrev->nHeight+1, nFees);
+      txNew.vin[0].scriptSig = CScript() << OP_0 << OP_0;
       //CTxOut minerTxOut = CTxOut(0, scriptPubKeyIn);
       CScript richpubkey;
       if(!RichList.NextRichScriptPubKey(richpubkey))
@@ -378,14 +382,13 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, int algo)
       txNew.vout.push_back(EIASTxOut);
       pblock->vtx[0] = txNew;
       pblocktemplate->vTxFees[0] = -nFees;
-      
-      
+
+
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
     UpdateTime(*pblock, pindexPrev);
     pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, algo);
     pblock->nNonce         = 0;
-    pblock->vtx[0].vin[0].scriptSig = CScript() << OP_0 << OP_0;
     pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
     CBlockIndex indexDummy(*pblock);
@@ -414,9 +417,11 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
   }
   ++nExtraNonce;
   unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
-  pblock->vtx[0].vin[0].scriptSig = (CScript() << nHeight << CBigNum(nExtraNonce)) + COINBASE_FLAGS;
-  assert(pblock->vtx[0].vin[0].scriptSig.size() <= 100);
+  CMutableTransaction txCoinbase(pblock->vtx[0]);
+  txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CBigNum(nExtraNonce)) + COINBASE_FLAGS;
+  assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
+  pblock->vtx[0] = txCoinbase;
   pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -440,7 +440,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     qint64 nPayAmount = 0;
     bool fLowOutput = false;
     bool fDust = false;
-    CTransaction txDummy;
+    CMutableTransaction txDummy;
     foreach(const qint64 &amount, CoinControlDialog::payAmounts)
     {
         nPayAmount += amount;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -21,7 +21,7 @@ double GetDifficulty(const CBlockIndex* blockindex, int algo)
 {
     unsigned int nBits;
     unsigned int nBitsSync;
-    
+
     // Floating point number that is a multiple of the minimum difficulty,
     // minimum difficulty = 1.0.
     if (blockindex == NULL)
@@ -65,9 +65,11 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
 {
     Object result;
     result.push_back(Pair("hash", block.GetHash().GetHex()));
-    CMerkleTx txGen(block.vtx[0]);
-    txGen.SetMerkleBranch(&block);
-    result.push_back(Pair("confirmations", (int)txGen.GetDepthInMainChain()));
+    int confirmations = -1;
+    // Only report confirmations if the block is on the main chain
+    if (chainActive.Contains(blockindex))
+        confirmations = chainActive.Height() - blockindex->nHeight + 1;
+    result.push_back(Pair("confirmations", confirmations));
     result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
     result.push_back(Pair("height", blockindex->nHeight));
     result.push_back(Pair("version", block.nVersion));
@@ -257,7 +259,7 @@ Value getblock(const Array& params, bool fHelp)
             "\nResult (for verbose = true):\n"
             "{\n"
             "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
-            "  \"confirmations\" : n,   (numeric) The number of confirmations\n"
+            "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
             "  \"size\" : n,            (numeric) The block size\n"
             "  \"height\" : n,          (numeric) The block height or index\n"
             "  \"version\" : n,         (numeric) The block version\n"

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -22,36 +22,6 @@
 using namespace json_spirit;
 using namespace std;
 
-#ifdef ENABLE_WALLET
-// Key used by getwork miners.
-// Allocated in InitRPCMining, free'd in ShutdownRPCMining
-static CReserveKey* pMiningKey = NULL;
-
-void InitRPCMining()
-{
-    if (!pwalletMain)
-        return;
-
-    // getwork/getblocktemplate mining rewards paid here:
-    pMiningKey = new CReserveKey(pwalletMain);
-}
-
-void ShutdownRPCMining()
-{
-    if (!pMiningKey)
-        return;
-
-    delete pMiningKey; pMiningKey = NULL;
-}
-#else
-void InitRPCMining()
-{
-}
-void ShutdownRPCMining()
-{
-}
-#endif
-
 // Return average network hashes per second based on the last 'lookup' blocks,
 // or from the last difficulty change if 'lookup' is nonpositive.
 // If 'height' is nonnegative, compute the estimate at the time when a given block was found.
@@ -128,9 +98,6 @@ Value getgenerate(const Array& params, bool fHelp)
             + HelpExampleCli("getgenerate", "")
             + HelpExampleRpc("getgenerate", "")
         );
-
-    if (!pMiningKey)
-        return false;
 
     return GetBoolArg("-gen", false);
 }
@@ -280,133 +247,6 @@ Value getmininginfo(const Array& params, bool fHelp)
 #endif
     return obj;
 }
-
-
-#ifdef ENABLE_WALLET
-Value getwork(const Array& params, bool fHelp)
-{
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-            "getwork ( \"data\" )\n"
-            "\nIf 'data' is not specified, it returns the formatted hash data to work on.\n"
-            "If 'data' is specified, tries to solve the block and returns true if it was successful.\n"
-            "\nArguments:\n"
-            "1. \"data\"       (string, optional) The hex encoded data to solve\n"
-            "\nResult (when 'data' is not specified):\n"
-            "{\n"
-            "  \"midstate\" : \"xxxx\",   (string) The precomputed hash state after hashing the first half of the data (DEPRECATED)\n" // deprecated
-            "  \"data\" : \"xxxxx\",      (string) The block data\n"
-            "  \"hash1\" : \"xxxxx\",     (string) The formatted hash buffer for second hash (DEPRECATED)\n" // deprecated
-            "  \"target\" : \"xxxx\"      (string) The little endian hash target\n"
-            "}\n"
-            "\nResult (when 'data' is specified):\n"
-            "true|false       (boolean) If solving the block specified in the 'data' was successfull\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getwork", "")
-            + HelpExampleRpc("getwork", "")
-        );
-
-    if (vNodes.empty())
-        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Smileycoin is not connected!");
-
-    if (IsInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Smileycoin is downloading blocks...");
-
-    typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
-    static mapNewBlock_t mapNewBlock;    // FIXME: thread safety
-    static vector<CBlockTemplate*> vNewBlockTemplate;
-
-    if (params.size() == 0)
-    {
-        // Update block
-        static unsigned int nTransactionsUpdatedLast;
-        static CBlockIndex* pindexPrev;
-        static int64_t nStart;
-        static CBlockTemplate* pblocktemplate;
-        if (pindexPrev != chainActive.Tip() ||
-            (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 60))
-        {
-            if (pindexPrev != chainActive.Tip())
-            {
-                // Deallocate old blocks since they're obsolete now
-                mapNewBlock.clear();
-                BOOST_FOREACH(CBlockTemplate* pblocktemplate, vNewBlockTemplate)
-                    delete pblocktemplate;
-                vNewBlockTemplate.clear();
-            }
-
-            // Clear pindexPrev so future getworks make a new block, despite any failures from here on
-            pindexPrev = NULL;
-
-            // Store the pindexBest used before CreateNewBlock, to avoid races
-            nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-            CBlockIndex* pindexPrevNew = chainActive.Tip();
-            nStart = GetTime();
-
-            // Create new block
-            pblocktemplate = CreateNewBlockWithKey(*pMiningKey, miningAlgo);
-            if (!pblocktemplate)
-                throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
-            vNewBlockTemplate.push_back(pblocktemplate);
-
-            // Need to update only after we know CreateNewBlock succeeded
-            pindexPrev = pindexPrevNew;
-        }
-        CBlock* pblock = &pblocktemplate->block; // pointer for convenience
-
-        // Update nTime
-        UpdateTime(*pblock, pindexPrev);
-        pblock->nNonce = 0;
-
-        // Update nExtraNonce
-        static unsigned int nExtraNonce = 0;
-        IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
-
-        // Save
-        mapNewBlock[pblock->hashMerkleRoot] = make_pair(pblock, pblock->vtx[0].vin[0].scriptSig);
-
-        // Pre-build hash buffers
-        char pmidstate[32];
-        char pdata[128];
-        char phash1[64];
-        FormatHashBuffers(pblock, pmidstate, pdata, phash1);
-
-        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
-
-        Object result;
-        result.push_back(Pair("midstate", HexStr(BEGIN(pmidstate), END(pmidstate)))); // deprecated
-        result.push_back(Pair("data",     HexStr(BEGIN(pdata), END(pdata))));
-        result.push_back(Pair("hash1",    HexStr(BEGIN(phash1), END(phash1)))); // deprecated
-        result.push_back(Pair("target",   HexStr(BEGIN(hashTarget), END(hashTarget))));
-        return result;
-    }
-    else
-    {
-        // Parse parameters
-        vector<unsigned char> vchData = ParseHex(params[0].get_str());
-        if (vchData.size() != 128)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter");
-        CBlock* pdata = (CBlock*)&vchData[0];
-
-        // Byte reverse
-        for (int i = 0; i < 128/4; i++)
-            ((unsigned int*)pdata)[i] = ByteReverse(((unsigned int*)pdata)[i]);
-
-        // Get saved block
-        if (!mapNewBlock.count(pdata->hashMerkleRoot))
-            return false;
-        CBlock* pblock = mapNewBlock[pdata->hashMerkleRoot].first;
-
-        pblock->nTime = pdata->nTime;
-        pblock->nNonce = pdata->nNonce;
-        pblock->vtx[0].vin[0].scriptSig = mapNewBlock[pdata->hashMerkleRoot].second;
-        pblock->hashMerkleRoot = pblock->BuildMerkleTree();
-
-        assert(pwalletMain != NULL);
-        return CheckWork(pblock, *pwalletMain, *pMiningKey);
-    }
-}
-#endif
 
 Value getblocktemplate(const Array& params, bool fHelp)
 {

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -358,7 +358,7 @@ Value createrawtransaction(const Array& params, bool fHelp)
     Array inputs = params[0].get_array();
     Object sendTo = params[1].get_obj();
 
-    CTransaction rawTx;
+    CMutableTransaction rawTx;
 
     BOOST_FOREACH(const Value& input, inputs)
     {
@@ -591,11 +591,11 @@ Value signrawtransaction(const Array& params, bool fHelp)
 
     vector<unsigned char> txData(ParseHexV(params[0], "argument 1"));
     CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);
-    vector<CTransaction> txVariants;
+    vector<CMutableTransaction> txVariants;
     while (!ssData.empty())
     {
         try {
-            CTransaction tx;
+            CMutableTransaction tx;
             ssData >> tx;
             txVariants.push_back(tx);
         }
@@ -609,7 +609,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
 
     // mergedTx will end up with all the signatures; it
     // starts as a clone of the rawtx:
-    CTransaction mergedTx(txVariants[0]);
+    CMutableTransaction mergedTx(txVariants[0]);
     bool fComplete = true;
 
     // Fetch previous transactions (inputs):
@@ -750,7 +750,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
             SignSignature(keystore, prevPubKey, mergedTx, i, nHashType);
 
         // ... and merge in other signatures:
-        BOOST_FOREACH(const CTransaction& txv, txVariants)
+        BOOST_FOREACH(const CMutableTransaction& txv, txVariants)
         {
             txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.vin[i].scriptSig);
         }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -329,7 +329,6 @@ static const CRPCCommand vRPCCommands[] =
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },
     { "gethashespersec",        &gethashespersec,        true,      false,      false },
-    { "getwork",                &getwork,                true,      false,      true  },
     { "setgenerate",            &setgenerate,            true,      true,       false },
 #endif // ENABLE_WALLET
 };
@@ -755,7 +754,7 @@ void JSONRequest::parse(const Value& valRequest)
     if (valMethod.type() != str_type)
         throw JSONRPCError(RPC_INVALID_REQUEST, "Method must be a string");
     strMethod = valMethod.get_str();
-    if (strMethod != "getwork" && strMethod != "getblocktemplate")
+    if (strMethod != "getblocktemplate")
         LogPrint("rpc", "ThreadRPCServer method=%s\n", strMethod);
 
     // Parse params

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -153,7 +153,6 @@ extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHe
 extern json_spirit::Value getnetworkhashps(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gethashespersec(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmininginfo(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value getwork(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblocktemplate(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value submitblock(const json_spirit::Array& params, bool fHelp);
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1699,7 +1699,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 }
 
 
-bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CTransaction& txTo, unsigned int nIn, int nHashType)
+bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType)
 {
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
@@ -1734,7 +1734,7 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CTransa
     return VerifyScript(txin.scriptSig, fromPubKey, txTo, nIn, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, 0);
 }
 
-bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CTransaction& txTo, unsigned int nIn, int nHashType)
+bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType)
 {
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
@@ -1752,7 +1752,7 @@ static CScript PushAll(const vector<valtype>& values)
     return result;
 }
 
-static CScript CombineMultisig(CScript scriptPubKey, const CTransaction& txTo, unsigned int nIn,
+static CScript CombineMultisig(CScript scriptPubKey, const CMutableTransaction& txTo, unsigned int nIn,
                                const vector<valtype>& vSolutions,
                                vector<valtype>& sigs1, vector<valtype>& sigs2)
 {

--- a/src/script.h
+++ b/src/script.h
@@ -21,6 +21,7 @@
 class CCoins;
 class CKeyStore;
 class CTransaction;
+class CMutableTransaction;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 static const unsigned int MAX_OP_RETURN_RELAY = 80;      // bytes
@@ -696,8 +697,8 @@ bool IsMine(const CKeyStore& keystore, const CTxDestination &dest);
 void ExtractAffectedKeys(const CKeyStore &keystore, const CScript& scriptPubKey, std::vector<CKeyID> &vKeys);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
 bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet);
-bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL);
-bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL);
+bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL);
+bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL);
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn, unsigned int flags, int nHashType);
 
 bool ContainsOpReturn(const CTransaction &tx);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -8,6 +8,7 @@
 #include "base58.h"
 #include "checkpoints.h"
 #include "coincontrol.h"
+#include "core.h"
 #include "net.h"
 
 #include <boost/algorithm/string/replace.hpp>
@@ -1229,6 +1230,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
     }
 
     wtxNew.BindWallet(this);
+    CMutableTransaction txNew;
 
     {
         LOCK2(cs_main, cs_wallet);
@@ -1236,8 +1238,8 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
             nFeeRet = nTransactionFee;
             while (true)
             {
-                wtxNew.vin.clear();
-                wtxNew.vout.clear();
+                txNew.vin.clear();
+                txNew.vout.clear();
                 wtxNew.fFromMe = true;
 
                 int64_t nTotalValue = nValue + nFeeRet;
@@ -1259,7 +1261,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                         strFailReason = _("Transaction amount too small");
                         return false;
                     }
-                    wtxNew.vout.push_back(txout);
+                    txNew.vout.push_back(txout);
                 }
 
                 // Choose coins to use
@@ -1333,8 +1335,8 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                     else
                     {
                         // Insert change txn at random position:
-                        vector<CTxOut>::iterator position = wtxNew.vout.begin()+GetRandInt(wtxNew.vout.size()+1);
-                        wtxNew.vout.insert(position, newTxOut);
+                        vector<CTxOut>::iterator position = txNew.vout.begin()+GetRandInt(txNew.vout.size()+1);
+                        txNew.vout.insert(position, newTxOut);
                     }
                 }
                 else
@@ -1342,16 +1344,19 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
 
                 // Fill vin
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
-                    wtxNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second));
+                    txNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second));
 
                 // Sign
                 int nIn = 0;
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
-                    if (!SignSignature(*this, *coin.first, wtxNew, nIn++))
+                    if (!SignSignature(*this, *coin.first, txNew, nIn++))
                     {
                         strFailReason = _("Signing transaction failed");
                         return false;
                     }
+
+                // Embed the constructed transaction data in wtxNew.
+                *static_cast<CTransaction*>(&wtxNew) = CTransaction(txNew);
 
                 // Limit size
                 unsigned int nBytes = ::GetSerializeSize(*(CTransaction*)&wtxNew, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2094,3 +2094,100 @@ bool CWallet::GetDestData(const CTxDestination &dest, const std::string &key, st
     }
     return false;
 }
+
+int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
+{
+	AssertLockHeld(cs_main);
+	CBlock blockTmp;
+
+	if (pblock == NULL) {
+		CCoins coins;
+		if (pcoinsTip->GetCoins(GetHash(), coins)) {
+			CBlockIndex *pindex = chainActive[coins.nHeight];
+			if (pindex) {
+				if (!ReadBlockFromDisk(blockTmp, pindex))
+					return 0;
+				pblock = &blockTmp;
+			}
+		}
+	}
+
+	if (pblock) {
+		// Update the tx's hashBlock
+		hashBlock = pblock->GetHash();
+
+		// Locate the transaction
+		for (nIndex = 0; nIndex < (int)pblock->vtx.size(); nIndex++)
+			if (pblock->vtx[nIndex] == *(CTransaction*)this)
+				break;
+		if (nIndex == (int)pblock->vtx.size())
+		{
+			vMerkleBranch.clear();
+			nIndex = -1;
+			LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
+			return 0;
+		}
+
+		// Fill in merkle branch
+		vMerkleBranch = pblock->GetMerkleBranch(nIndex);
+	}
+
+	// Is the tx in a block that's in the main chain
+	map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashBlock);
+	if (mi == mapBlockIndex.end())
+		return 0;
+	CBlockIndex* pindex = (*mi).second;
+	if (!pindex || !chainActive.Contains(pindex))
+		return 0;
+
+	return chainActive.Height() - pindex->nHeight + 1;
+}
+
+int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
+{
+	if (hashBlock == 0 || nIndex == -1)
+		return 0;
+	AssertLockHeld(cs_main);
+
+	// Find the block it claims to be in
+	map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashBlock);
+	if (mi == mapBlockIndex.end())
+		return 0;
+	CBlockIndex* pindex = (*mi).second;
+	if (!pindex || !chainActive.Contains(pindex))
+		return 0;
+
+	// Make sure the merkle branch connects to this block
+	if (!fMerkleVerified)
+	{
+		if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
+			return 0;
+		fMerkleVerified = true;
+	}
+
+	pindexRet = pindex;
+	return chainActive.Height() - pindex->nHeight + 1;
+}
+
+int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
+{
+	AssertLockHeld(cs_main);
+	int nResult = GetDepthInMainChainINTERNAL(pindexRet);
+	if (nResult == 0 && !mempool.exists(GetHash()))
+		return -1; // Not in chain, not in mempool
+
+	return nResult;
+}
+
+int CMerkleTx::GetBlocksToMaturity(int nHeight) const
+{
+	if (!IsCoinBase())
+		return 0;
+	return max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
+}
+
+bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree)
+{
+	CValidationState state;
+	return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, NULL);
+}

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -456,6 +456,62 @@ static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
     mapValue["n"] = i64tostr(nOrderPos);
 }
 
+/** A transaction with a merkle branch linking it to the block chain. */
+class CMerkleTx : public CTransaction
+{
+private:
+    int GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const;
+
+public:
+    uint256 hashBlock;
+    std::vector<uint256> vMerkleBranch;
+    int nIndex;
+
+    // memory only
+    mutable bool fMerkleVerified;
+
+
+    CMerkleTx()
+    {
+        Init();
+    }
+
+    CMerkleTx(const CTransaction& txIn) : CTransaction(txIn)
+    {
+        Init();
+    }
+
+    void Init()
+    {
+        hashBlock = 0;
+        nIndex = -1;
+        fMerkleVerified = false;
+    }
+
+
+    IMPLEMENT_SERIALIZE
+    (
+        nSerSize += SerReadWrite(s, *(CTransaction*)this, nType, nVersion, ser_action);
+        nVersion = this->nVersion;
+        READWRITE(hashBlock);
+        READWRITE(vMerkleBranch);
+        READWRITE(nIndex);
+    )
+
+
+    int SetMerkleBranch(const CBlock* pblock=NULL);
+
+    // Return depth of transaction in blockchain:
+    // -1  : not in blockchain, and not in memory pool (conflicted transaction)
+    //  0  : in memory pool, waiting to be included in a block
+    // >=1 : this many blocks deep in the main chain
+    int GetDepthInMainChain(CBlockIndex* &pindexRet) const;
+    int GetDepthInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
+    bool IsInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
+    int GetBlocksToMaturity(int nHeight) const;
+    bool AcceptToMemoryPool(bool fLimitFree=true);
+};
+
 
 /** A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.


### PR DESCRIPTION
* The getwork RPC call has been superseeded by getblocktemplate and has been removed
* Make CTransaction immutable and add a CMutableTransaction class
* Stop using CMerkleTX for fetching blockheight in RPC as we already have CBlockIndex in RPC
* Move CMerkleTx to wallet.cpp/h now that it's only used by the wallet.